### PR TITLE
Install from nightly zip files

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -35,7 +35,7 @@ database.
 
 .. code:: console
 
-    finagg install -ss economic -ts indices -z
+    finagg install -ss economic -ts indices -z -r
 
 The installation will point you where to get free API keys and write them to a
 local ``.env`` file for storage. Run ``finagg install --help`` for more

--- a/README.rst
+++ b/README.rst
@@ -37,9 +37,9 @@ database.
 
     finagg install -ss economic -ts indices -z -r
 
-The installation will point you where to get free API keys and write them to a
-local ``.env`` file for storage. Run ``finagg install --help`` for more
-installation options and details.
+The installation will point you where to get free API keys and will write
+them to a local ``.env`` file for storage. Run ``finagg install --help``
+for more installation options and details.
 
 Basic Usage
 -----------

--- a/README.rst
+++ b/README.rst
@@ -37,9 +37,9 @@ database.
 
     finagg install -ss economic -ts indices -z -r
 
-The installation will point you where to get free API keys and will write
-them to a local ``.env`` file for storage. Run ``finagg install --help``
-for more installation options and details.
+The installation will point you where to get free API keys for each API that
+requires one and will write those API keys to a local ``.env`` file for storage.
+Run ``finagg install --help`` for more installation options and details.
 
 Basic Usage
 -----------

--- a/README.rst
+++ b/README.rst
@@ -34,7 +34,7 @@ SQL database.
 
 .. code:: console
 
-    finagg install --help
+    finagg install --ticker-set indices --from-zip
 
 The installation will point you where to get free API keys and write them to a
 local ``.env`` file for storage.

--- a/README.rst
+++ b/README.rst
@@ -29,15 +29,17 @@ Install from GitHub for the latest (unstable) version.
     git clone https://github.com/theOGognf/finagg.git
     pip install ./finagg/
 
-Optionally install the recommended datasets from 3rd party APIs into a local
-SQL database.
+Optionally install the recommended datasets (economic data, company
+financials, stock histories, etc.) from 3rd party APIs into a local SQL
+database.
 
 .. code:: console
 
-    finagg install --ticker-set indices --from-zip
+    finagg install -ss economic -ts indices -z
 
 The installation will point you where to get free API keys and write them to a
-local ``.env`` file for storage.
+local ``.env`` file for storage. Run `finagg install --help` for more
+installation options and details.
 
 Basic Usage
 -----------

--- a/README.rst
+++ b/README.rst
@@ -38,7 +38,7 @@ database.
     finagg install -ss economic -ts indices -z
 
 The installation will point you where to get free API keys and write them to a
-local ``.env`` file for storage. Run `finagg install --help` for more
+local ``.env`` file for storage. Run ``finagg install --help`` for more
 installation options and details.
 
 Basic Usage

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -19,7 +19,7 @@ SQL database.
 
 .. code:: console
 
-    finagg install --help
+    finagg install --ticker-set indices --from-zip
 
 The installation will point you where to get free API keys for each API that
 requires one and write those API keys to a local ``.env`` file for storage.

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -23,7 +23,7 @@ database.
     finagg install -ss economic -ts indices -z -r
 
 The installation will point you where to get free API keys for each API that
-requires one and write those API keys to a local ``.env`` file for storage.
+requires one and will write those API keys to a local ``.env`` file for storage.
 ``finagg install`` is effectively an alias for installing the recommended
 datasets from each 3rd party API individually. ``finagg install`` is equivalent
 to:

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -20,7 +20,7 @@ database.
 
 .. code:: console
 
-    finagg install -ss economic -ts indices -z
+    finagg install -ss economic -ts indices -z -r
 
 The installation will point you where to get free API keys for each API that
 requires one and write those API keys to a local ``.env`` file for storage.

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -14,12 +14,13 @@ Install from GitHub for the latest (unstable) version.
     git clone https://github.com/theOGognf/finagg.git
     pip install ./finagg/
 
-Optionally install the recommended datasets from 3rd party APIs into a local
-SQL database.
+Optionally install the recommended datasets (economic data, company
+financials, stock histories, etc.) from 3rd party APIs into a local SQL
+database.
 
 .. code:: console
 
-    finagg install --ticker-set indices --from-zip
+    finagg install -ss economic -ts indices -z
 
 The installation will point you where to get free API keys for each API that
 requires one and write those API keys to a local ``.env`` file for storage.

--- a/src/finagg/__main__.py
+++ b/src/finagg/__main__.py
@@ -123,10 +123,9 @@ cli.add_command(yfinance._cli.entry_point, "yfinance")
     is_flag=True,
     default=False,
     help=(
-        "Whether to install raw SEC data from bulk data zip files that're compiled by"
-        " the SEC nightly. If this flag is set and no tickers are specified, then all"
-        " data associated with all tickers is installed. Installing all SEC data with"
-        " this option can take upwards of 1.5 hours to complete."
+        "Whether to install raw data from bulk data zip files that're compiled by the"
+        " SEC nightly. Installing all SEC data with this option can take upwards of 1.5"
+        " hours to complete."
     ),
 )
 @click.option(

--- a/src/finagg/__main__.py
+++ b/src/finagg/__main__.py
@@ -118,6 +118,18 @@ cli.add_command(yfinance._cli.entry_point, "yfinance")
     ),
 )
 @click.option(
+    "--from-zip",
+    "-z",
+    is_flag=True,
+    default=False,
+    help=(
+        "Whether to install raw SEC data from bulk data zip files that're compiled by"
+        " the SEC nightly. If this flag is set and no tickers are specified, then all"
+        " data associated with all tickers is installed. Installing all SEC data with"
+        " this option can take upwards of 1.5 hours to complete."
+    ),
+)
+@click.option(
     "--recreate-tables",
     "-r",
     is_flag=True,
@@ -143,6 +155,7 @@ def install(
     stock_data: bool = False,
     ticker: list[str] = [],
     ticker_set: None | Literal["indices", "sec"] = None,
+    from_zip: bool = False,
     recreate_tables: bool = False,
     verbose: bool = False,
 ) -> None:
@@ -184,6 +197,7 @@ def install(
             all_=True,
             ticker=ticker,
             ticker_set=ticker_set,
+            from_zip=from_zip,
             recreate_tables=recreate_tables,
             verbose=verbose,
         )

--- a/src/finagg/fred/feat/_refined.py
+++ b/src/finagg/fred/feat/_refined.py
@@ -242,15 +242,19 @@ class Economic:
             sql.economic.drop(engine, checkfirst=True)
             sql.economic.create(engine)
 
-        df = cls.from_raw(engine=engine)
-        rowcount = len(df.index)
-        if rowcount:
-            cls.to_refined(df, engine=engine)
-            rowcount += rowcount
-            logger.debug(f"{rowcount} economic feature rows inserted")
-        else:
-            logger.debug("Skipping economic features due to missing data")
-        return rowcount
+        total_rows = 0
+        try:
+            df = cls.from_raw(engine=engine)
+            rowcount = len(df.index)
+            if rowcount:
+                cls.to_refined(df, engine=engine)
+                total_rows += rowcount
+                logger.debug(f"{rowcount} economic feature rows inserted")
+            else:
+                logger.debug("Skipping economic features due to missing data")
+        except Exception as e:
+            logger.debug(f"Skipping economic features", exc_info=e)
+        return total_rows
 
     @classmethod
     def to_refined(

--- a/src/finagg/sec/_cli.py
+++ b/src/finagg/sec/_cli.py
@@ -102,9 +102,8 @@ def entry_point() -> None:
     default=False,
     help=(
         "Whether to install raw data from bulk data zip files that're compiled by the"
-        " SEC nightly. If this flag is set and no tickers are specified, then all data"
-        " associated with all tickers is installed. Installing all SEC data with this"
-        " option can take upwards of 1.5 hours to complete."
+        " SEC nightly. Installing all SEC data with this option can take upwards of 1.5"
+        " hours to complete."
     ),
 )
 @click.option(
@@ -169,7 +168,7 @@ def install(
             case "sec":
                 all_tickers |= _api.get_ticker_set()
 
-        if not all_tickers and not from_zip:
+        if not all_tickers:
             logger.info(
                 f"Skipping {__package__} installation because no tickers were "
                 "provided (by the `ticker` option or by the `ticker-set` option)"

--- a/src/finagg/sec/api.py
+++ b/src/finagg/sec/api.py
@@ -364,7 +364,7 @@ class CompanyFacts(API):
         url = cls.url.format(cik=cik)
         response = _get(url, user_agent=user_agent)
         content = response.json()
-        df = parse_facts(content)
+        df = _parse_facts(content)
         df["cik"] = cik
         return df
 
@@ -619,7 +619,7 @@ class Submissions(API):
         df.columns = map(utils.snake_case, df.columns)  # type: ignore
         df.rename(columns={"accession_number": "accn"})
         df["cik"] = cik
-        metadata = parse_metadata(content)
+        metadata = _parse_metadata(content)
         metadata["cik"] = cik
         metadata["ticker"] = str(ticker)
         return {"metadata": metadata, "filings": df}
@@ -1071,7 +1071,20 @@ def join_filings(df: pd.DataFrame, /, *, form: str = "10-Q") -> pd.DataFrame:
     return df
 
 
-def parse_facts(content: dict[str, Any], /) -> pd.DataFrame:
+def _parse_facts(content: dict[str, Any], /) -> pd.DataFrame:
+    """Helper for parsing company facts.
+
+    This function is only defined to make parsing company
+    facts easier and common between parsing from the REST
+    API responses and the bulk zip file.
+
+    Args:
+        content: Company facts JSON data.
+
+    Returns:
+        A dataframe equivalent of the company facts data.
+
+    """
     facts = content.pop("facts")
     results_list = []
     for taxonomy, tag_dict in facts.items():
@@ -1092,7 +1105,20 @@ def parse_facts(content: dict[str, Any], /) -> pd.DataFrame:
     )
 
 
-def parse_metadata(content: dict[str, Any], /) -> dict[str, Any]:
+def _parse_metadata(content: dict[str, Any], /) -> dict[str, Any]:
+    """Helper for parsing submission metadata.
+
+    This function is only defined to make parsing submission
+    metadata easier and common between parsing from the REST
+    API responses and the bulk zip file.
+
+    Args:
+        content: Submissions JSON data.
+
+    Returns:
+        A dataframe equivalent of the submissions data.
+
+    """
     metadata = {}
     for k, v in content.items():
         if isinstance(v, str):

--- a/src/finagg/sec/api.py
+++ b/src/finagg/sec/api.py
@@ -790,7 +790,7 @@ def _get(
     url: str,
     /,
     *,
-    cache: bool = False,
+    cache: bool = True,
     stream: bool = False,
     user_agent: None | str = None,
 ) -> requests.Response:
@@ -798,6 +798,9 @@ def _get(
 
     Args:
         url: Complete SEC EDGAR API URL to request from.
+        cache: Whether to cache the response from the given URL.
+        stream: Whether to stream the response content (useful for file
+            downloads).
         user_agent: Self-declared SEC bot header. Defaults to the value
             found in the ``SEC_API_USER_AGENT`` environment variable.
 

--- a/src/finagg/sec/feat/_raw.py
+++ b/src/finagg/sec/feat/_raw.py
@@ -238,7 +238,7 @@ class Submissions:
 
         # Filter by guaranteeing a ticker is actually present in
         # the set of tickers provided.
-        if tickers is not None:
+        if tickers:
             files = []
             for f in zipfile.namelist():
                 try:

--- a/src/finagg/sec/feat/_raw.py
+++ b/src/finagg/sec/feat/_raw.py
@@ -238,17 +238,15 @@ class Submissions:
 
         # Filter by guaranteeing a ticker is actually present in
         # the set of tickers provided.
-        if tickers:
-            files = []
-            for f in zipfile.namelist():
-                try:
-                    ticker = api.get_ticker(f[3:-5])
-                except KeyError:
-                    continue
-                if ticker in tickers:
-                    files.append(f)
-        else:
-            files = zipfile.namelist()
+        tickers = tickers or indices.api.get_ticker_set()
+        files = []
+        for f in zipfile.namelist():
+            try:
+                ticker = api.get_ticker(f[3:-5])
+            except KeyError:
+                continue
+            if ticker in tickers:
+                files.append(f)
 
         total_rows = 0
         for f in tqdm(
@@ -449,7 +447,7 @@ class Tags:
 
         Args:
             tickers: Set of tickers to install features for. Defaults to all
-                the tickers from :meth:`finagg.indices.api.get_ticker_set`.
+                the tickers from :meth:`Submissions.get_ticker_set`.
             engine: Feature store database engine. Defaults to the engine
                 at :data:`finagg.backend.engine`.
             recreate_tables: Whether to drop and recreate tables, wiping all
@@ -459,7 +457,7 @@ class Tags:
             Number of rows written to the feature's SQL table.
 
         """
-        tickers = tickers or indices.api.get_ticker_set()
+        tickers = tickers or Submissions.get_ticker_set()
         engine = engine or backend.engine
         if recreate_tables or not sa.inspect(engine).has_table(sql.tags.name):
             sql.tags.drop(engine, checkfirst=True)
@@ -519,7 +517,7 @@ class Tags:
 
         Args:
             tickers: Set of tickers to install features for. Defaults to all
-                tickers from the company facts zip file.
+                the tickers from :meth:`Submissions.get_ticker_set`.
             engine: Feature store database engine. Defaults to the engine
                 at :data:`finagg.backend.engine`.
             recreate_tables: Whether to drop and recreate tables, wiping all

--- a/src/finagg/sec/feat/_raw.py
+++ b/src/finagg/sec/feat/_raw.py
@@ -215,7 +215,7 @@ class Submissions:
 
         Args:
             tickers: Set of tickers to install features for. Defaults to all
-                tickers from the submission zip file.
+                the tickers from :meth:`finagg.indices.api.get_ticker_set`.
             engine: Feature store database engine. Defaults to the engine
                 at :data:`finagg.backend.engine`.
             recreate_tables: Whether to drop and recreate tables, wiping all

--- a/src/finagg/sec/feat/_refined/annual.py
+++ b/src/finagg/sec/feat/_refined/annual.py
@@ -880,7 +880,7 @@ class Annual:
             logger.info(
                 "Skipping finagg.sec.feat.annual installation because no tickers were"
                 " provided or no tickers were found with prerequisite data (i.e.,"
-                " finagg.sec.feat.submissions and finagg.sec.feat.raw data)"
+                " finagg.sec.feat.submissions and finagg.sec.feat.tags data)"
             )
             return 0
 

--- a/src/finagg/sec/feat/_refined/quarterly.py
+++ b/src/finagg/sec/feat/_refined/quarterly.py
@@ -897,7 +897,7 @@ class Quarterly:
             logger.info(
                 "Skipping finagg.sec.feat.quarterly installation because no tickers"
                 " were provided or no tickers were found with prerequisite data (i.e.,"
-                " finagg.sec.feat.submissions and finagg.sec.feat.raw data)"
+                " finagg.sec.feat.submissions and finagg.sec.feat.tags data)"
             )
             return 0
 

--- a/src/finagg/yfinance/api.py
+++ b/src/finagg/yfinance/api.py
@@ -53,6 +53,7 @@ def get(
         start=start,
         end=end,
         auto_adjust=True,
+        debug=False,
     )
     df.index = pd.to_datetime(df.index).date.astype(str)
     df = df.rename_axis("date").reset_index()

--- a/src/finagg/yfinance/api.py
+++ b/src/finagg/yfinance/api.py
@@ -15,7 +15,7 @@ def get(
     start: None | str = None,
     end: None | str = None,
     interval: str = "1d",
-    period: str = "10y",
+    period: str = "max",
 ) -> pd.DataFrame:
     """Get a ticker's stock price history.
 

--- a/src/finagg/yfinance/api.py
+++ b/src/finagg/yfinance/api.py
@@ -1,7 +1,11 @@
 """Simple wrappers for Yahoo! Finance."""
 
+import logging
+
 import pandas as pd
 import yfinance as yf
+
+logging.getLogger("yfinance").setLevel(logging.CRITICAL)
 
 
 def get(
@@ -12,7 +16,6 @@ def get(
     end: None | str = None,
     interval: str = "1d",
     period: str = "max",
-    debug: bool = False,
 ) -> pd.DataFrame:
     """Get a ticker's stock price history.
 
@@ -28,7 +31,6 @@ def get(
         interval: Frequency at which stock price history is grabbed.
         period: Time period to get in the past. ``"max"`` returns the full
             stock price history and the default.
-        debug: Debug mode passed to the Yahoo! Finance scraper.
 
     Returns:
         Yahoo! Finance auto-adjusted stock price history with slightly
@@ -51,7 +53,6 @@ def get(
         start=start,
         end=end,
         auto_adjust=True,
-        debug=debug,
     )
     df.index = pd.to_datetime(df.index).date.astype(str)
     df = df.rename_axis("date").reset_index()

--- a/src/finagg/yfinance/api.py
+++ b/src/finagg/yfinance/api.py
@@ -15,7 +15,7 @@ def get(
     start: None | str = None,
     end: None | str = None,
     interval: str = "1d",
-    period: str = "max",
+    period: str = "10y",
 ) -> pd.DataFrame:
     """Get a ticker's stock price history.
 

--- a/src/finagg/yfinance/feat/_raw.py
+++ b/src/finagg/yfinance/feat/_raw.py
@@ -164,7 +164,7 @@ class Prices:
             leave=True,
         ):
             try:
-                df = api.get(ticker, interval="1d", period="max")
+                df = api.get(ticker, interval="1d", period="10y")
                 rowcount = len(df.index)
                 if rowcount:
                     cls.to_raw(df, engine=engine)

--- a/src/finagg/yfinance/feat/_raw.py
+++ b/src/finagg/yfinance/feat/_raw.py
@@ -164,7 +164,7 @@ class Prices:
             leave=True,
         ):
             try:
-                df = api.get(ticker, interval="1d", period="10y")
+                df = api.get(ticker)
                 rowcount = len(df.index)
                 if rowcount:
                     cls.to_raw(df, engine=engine)


### PR DESCRIPTION
Covers https://github.com/theOGognf/finagg/issues/24.

- Added `--from-zip` args to `finagg install` and `finagg sec install` commands to trigger downloads of zip files instead of hitting the respective REST APIs for each company/tag pair
- Added `finagg.sec.api.submissions.download_zip()` function
- Added `finagg.sec.api.company_facts.download_zip()` function
- Added `finagg.sec.feat.submissions.install_from_zip()` function
- Added `finagg.sec.feat.tags.install_from_zip()` function
- Updated docs and README to detail new (and recommended) install functionality