### PR TITLE
FRED API result pagination

### DIFF
--- a/src/finagg/fred/api/_api.py
+++ b/src/finagg/fred/api/_api.py
@@ -50,14 +50,26 @@ def get(url: str, /, **kwargs: Any) -> requests.Response:
     return response
 
 
-def paginate(data_key: str, url: str, /, **kwargs: Any) -> pd.DataFrame:
+def maybe_paginate(data_key: str, url: str, /, **kwargs: Any) -> pd.DataFrame:
+    """Do pagination for API get functions that support pagination (if
+    pagination is enabled).
+
+    Args:
+        data_key: Key from the response that the underlying data resides in.
+        url: Request URL.
+        **kwargs: Mapping of request parameter name to their value.
+
+    Returns:
+        A dataframe.
+
+    """
     do_paginate = kwargs.pop("paginate", False)
     offset = kwargs.pop("offset", 0)
     getter = partial(get, url, **kwargs)
 
-    buffer = []
+    buffer: list[dict[str, Any]] = []
     batch_size = kwargs.get("limit", 1000)
-    data = {"count": 0}
+    data = {"count": offset}
     i = offset
     while not buffer or i <= data["count"]:
         data = getter(offset=i).json()

--- a/src/finagg/fred/api/_api.py
+++ b/src/finagg/fred/api/_api.py
@@ -60,7 +60,7 @@ def maybe_paginate(data_key: str, url: str, /, **kwargs: Any) -> pd.DataFrame:
         **kwargs: Mapping of request parameter name to their value.
 
     Returns:
-        A dataframe.
+        A dataframe containing (possibly all) data results.
 
     """
     do_paginate = kwargs.pop("paginate", False)

--- a/src/finagg/fred/api/_category.py
+++ b/src/finagg/fred/api/_category.py
@@ -154,6 +154,7 @@ class CategorySeries(_api.API):
         filter_value: None | str = None,
         tag_names: None | str | list[str] = None,
         exclude_tag_names: None | str | list[str] = None,
+        paginate: bool = False,
         api_key: None | str = None,
     ) -> pd.DataFrame:
         """Get series within a category.
@@ -192,6 +193,8 @@ class CategorySeries(_api.API):
                 by.
             tag_names: Find tags related to these tags.
             exclude_tag_names: Exclude tags related to these tags.
+            paginate: Whether to manage `offset` automatically, making multiple
+                API calls until all results are returned.
             api_key: Your FRED API key. Defaults to the ``FRED_API_KEY``
                 environment variable.
 
@@ -208,7 +211,8 @@ class CategorySeries(_api.API):
             3   FFWSJLOW     2023-03-15   2023-03-15  Low Value of the Federal Funds Rate for the In... ...
 
         """
-        data = _api.get(
+        return _api.maybe_paginate(
+            "seriess",
             cls.url,
             category_id=category_id,
             realtime_start=realtime_start,
@@ -221,10 +225,9 @@ class CategorySeries(_api.API):
             filter_value=filter_value,
             tag_names=tag_names,
             exclude_tag_names=exclude_tag_names,
+            paginate=paginate,
             api_key=api_key,
-        ).json()
-        data = data["seriess"]
-        return pd.DataFrame(data)
+        )
 
 
 class CategoryTags(_api.API):
@@ -253,6 +256,7 @@ class CategoryTags(_api.API):
         offset: None | int = 0,
         order_by: None | str = None,
         sort_order: None | str = None,
+        paginate: bool = False,
         api_key: None | str = None,
     ) -> pd.DataFrame:
         """Get a FRED category's tags.
@@ -292,6 +296,8 @@ class CategoryTags(_api.API):
 
             sort_order: Sort results in ascending ("asc") or
                 descending ("desc") order.
+            paginate: Whether to manage `offset` automatically, making multiple
+                API calls until all results are returned.
             api_key: Your FRED API key. Defaults to the ``FRED_API_KEY``
                 environment variable.
 
@@ -309,7 +315,8 @@ class CategoryTags(_api.API):
             4          funds      gen  None  2020-05-11 13:13:02-05          28             8
 
         """
-        data = _api.get(
+        return _api.maybe_paginate(
+            "tags",
             cls.url,
             category_id=category_id,
             realtime_start=realtime_start,
@@ -321,10 +328,9 @@ class CategoryTags(_api.API):
             tag_names=tag_names,
             tag_group_id=tag_group_id,
             search_text=search_text,
+            paginate=paginate,
             api_key=api_key,
-        ).json()
-        data = data["tags"]
-        return pd.DataFrame(data)
+        )
 
 
 class CategoryRelatedTags(_api.API):
@@ -354,6 +360,7 @@ class CategoryRelatedTags(_api.API):
         offset: None | int = 0,
         order_by: None | str = None,
         sort_order: None | str = None,
+        paginate: bool = False,
         api_key: None | str = None,
     ) -> pd.DataFrame:
         """Get data for tags related to a category.
@@ -394,6 +401,8 @@ class CategoryRelatedTags(_api.API):
 
             sort_order: Sort results in ascending ("asc") or
                 descending ("desc") order.
+            paginate: Whether to manage `offset` automatically, making multiple
+                API calls until all results are returned.
             api_key: Your FRED API key. Defaults to the ``FRED_API_KEY``
                 environment variable.
 
@@ -420,7 +429,8 @@ class CategoryRelatedTags(_api.API):
             13                                wsj      rls       Wall Street Journal ...
 
         """
-        data = _api.get(
+        return _api.maybe_paginate(
+            "tags",
             cls.url,
             category_id=category_id,
             realtime_start=realtime_start,
@@ -433,10 +443,9 @@ class CategoryRelatedTags(_api.API):
             offset=offset,
             order_by=order_by,
             sort_order=sort_order,
+            paginate=paginate,
             api_key=api_key,
-        ).json()
-        data = data["tags"]
-        return pd.DataFrame(data)
+        )
 
 
 class Category(_api.API):

--- a/src/finagg/fred/api/_release.py
+++ b/src/finagg/fred/api/_release.py
@@ -33,6 +33,7 @@ class ReleasesDates(_api.API):
         order_by: None | str = "release_date",
         sort_order: None | str = "desc",
         include_release_dates_with_no_data: None | bool = False,
+        paginate: bool = False,
         api_key: None | str = None,
     ) -> pd.DataFrame:
         """Get all release dates of economic data.
@@ -58,6 +59,8 @@ class ReleasesDates(_api.API):
                 descending ("desc") order.
             include_release_dates_with_no_data: Whether to return release
                 dates that don't contain any data.
+            paginate: Whether to manage `offset` automatically, making multiple
+                API calls until all results are returned.
             api_key: Your FRED API key. Defaults to the ``FRED_API_KEY``
                 environment variable.
 
@@ -66,7 +69,8 @@ class ReleasesDates(_api.API):
             releases of economic data.
 
         """
-        data = _api.get(
+        return _api.maybe_paginate(
+            "release_dates",
             cls.url,
             realtime_start=realtime_start,
             realtime_end=realtime_end,
@@ -75,10 +79,9 @@ class ReleasesDates(_api.API):
             order_by=order_by,
             sort_order=sort_order,
             include_release_dates_with_no_data=include_release_dates_with_no_data,
+            paginate=paginate,
             api_key=api_key,
-        ).json()
-        data = data["release_dates"]
-        return pd.DataFrame(data)
+        )
 
 
 class Releases(_api.API):
@@ -104,6 +107,7 @@ class Releases(_api.API):
         offset: None | int = 0,
         order_by: None | str = None,
         sort_order: None | str = None,
+        paginate: bool = False,
         api_key: None | str = None,
     ) -> pd.DataFrame:
         """Get all releases of economic data.
@@ -129,6 +133,8 @@ class Releases(_api.API):
 
             sort_order: Sort results in ascending ("asc") or
                 descending ("desc") order.
+            paginate: Whether to manage `offset` automatically, making multiple
+                API calls until all results are returned.
             api_key: Your FRED API key. Defaults to the ``FRED_API_KEY``
                 environment variable.
 
@@ -137,7 +143,8 @@ class Releases(_api.API):
             data.
 
         """
-        data = _api.get(
+        return _api.maybe_paginate(
+            "releases",
             cls.url,
             realtime_start=realtime_start,
             realtime_end=realtime_end,
@@ -145,10 +152,9 @@ class Releases(_api.API):
             offset=offset,
             order_by=order_by,
             sort_order=sort_order,
+            paginate=paginate,
             api_key=api_key,
-        ).json()
-        data = data["releases"]
-        return pd.DataFrame(data)
+        )
 
 
 class ReleaseDates(_api.API):
@@ -174,6 +180,7 @@ class ReleaseDates(_api.API):
         offset: None | int = 0,
         sort_order: None | str = None,
         include_release_dates_with_no_data: None | bool = False,
+        paginate: bool = False,
         api_key: None | str = None,
     ) -> pd.DataFrame:
         """Get data on release dates for a particular release of economic data.
@@ -194,6 +201,8 @@ class ReleaseDates(_api.API):
                 descending ("desc") order.
             include_release_dates_with_no_data: Whether to return release
                 dates that don't contain any data.
+            paginate: Whether to manage `offset` automatically, making multiple
+                API calls until all results are returned.
             api_key: Your FRED API key. Defaults to the ``FRED_API_KEY``
                 environment variable.
 
@@ -201,7 +210,8 @@ class ReleaseDates(_api.API):
             A dataframe containing data for an economic data release's release dates.
 
         """
-        data = _api.get(
+        return _api.maybe_paginate(
+            "release_dates",
             cls.url,
             release_id=release_id,
             realtime_start=realtime_start,
@@ -210,10 +220,9 @@ class ReleaseDates(_api.API):
             offset=offset,
             sort_order=sort_order,
             include_release_dates_with_no_data=include_release_dates_with_no_data,
+            paginate=paginate,
             api_key=api_key,
-        ).json()
-        data = data["release_dates"]
-        return pd.DataFrame(data)
+        )
 
 
 class ReleaseSeries(_api.API):
@@ -243,6 +252,7 @@ class ReleaseSeries(_api.API):
         filter_value: None | str = None,
         tag_names: None | str | list[str] = None,
         exclude_tag_names: None | str | list[str] = None,
+        paginate: bool = False,
         api_key: None | str = None,
     ) -> pd.DataFrame:
         """Get data on the series related to a release of economic data.
@@ -287,6 +297,8 @@ class ReleaseSeries(_api.API):
                 by.
             tag_names: Find tags related to these tags.
             exclude_tag_names: Exclude tags related to these tags.
+            paginate: Whether to manage `offset` automatically, making multiple
+                API calls until all results are returned.
             api_key: Your FRED API key. Defaults to the ``FRED_API_KEY``
                 environment variable.
 
@@ -294,7 +306,8 @@ class ReleaseSeries(_api.API):
             A dataframe containing series data for a release.
 
         """
-        data = _api.get(
+        return _api.maybe_paginate(
+            "seriess",
             cls.url,
             release_id=release_id,
             realtime_start=realtime_start,
@@ -307,10 +320,9 @@ class ReleaseSeries(_api.API):
             filter_value=filter_value,
             tag_names=tag_names,
             exclude_tag_names=exclude_tag_names,
+            paginate=paginate,
             api_key=api_key,
-        ).json()
-        data = data["seriess"]
-        return pd.DataFrame(data)
+        )
 
 
 class ReleaseSources(_api.API):
@@ -390,6 +402,7 @@ class ReleaseTags(_api.API):
         offset: None | int = 0,
         order_by: None | str = None,
         sort_order: None | str = None,
+        paginate: bool = False,
         api_key: None | str = None,
     ) -> pd.DataFrame:
         """Get tags for an economic release.
@@ -428,6 +441,8 @@ class ReleaseTags(_api.API):
 
             sort_order: Sort results in ascending ("asc") or
                 descending ("desc") order.
+            paginate: Whether to manage `offset` automatically, making multiple
+                API calls until all results are returned.
             api_key: Your FRED API key. Defaults to the ``FRED_API_KEY``
                 environment variable.
 
@@ -436,7 +451,8 @@ class ReleaseTags(_api.API):
             according to the given parameters.
 
         """
-        data = _api.get(
+        return _api.maybe_paginate(
+            "tags",
             cls.url,
             release_id=release_id,
             realtime_start=realtime_start,
@@ -448,10 +464,9 @@ class ReleaseTags(_api.API):
             offset=offset,
             order_by=order_by,
             sort_order=sort_order,
+            paginate=paginate,
             api_key=api_key,
-        ).json()
-        data = data["tags"]
-        return pd.DataFrame(data)
+        )
 
 
 class ReleaseRelatedTags(_api.API):
@@ -481,6 +496,7 @@ class ReleaseRelatedTags(_api.API):
         offset: None | int = 0,
         order_by: None | str = None,
         sort_order: None | str = None,
+        paginate: bool = False,
         api_key: None | str = None,
     ) -> pd.DataFrame:
         """Get data for tags related to an economic release.
@@ -520,6 +536,8 @@ class ReleaseRelatedTags(_api.API):
 
             sort_order: Sort results in ascending ("asc") or
                 descending ("desc") order.
+            paginate: Whether to manage `offset` automatically, making multiple
+                API calls until all results are returned.
             api_key: Your FRED API key. Defaults to the ``FRED_API_KEY``
                 environment variable.
 
@@ -528,7 +546,8 @@ class ReleaseRelatedTags(_api.API):
             release according to the given parameters.
 
         """
-        data = _api.get(
+        return _api.maybe_paginate(
+            "tags",
             cls.url,
             release_id=release_id,
             realtime_start=realtime_start,
@@ -541,10 +560,9 @@ class ReleaseRelatedTags(_api.API):
             offset=offset,
             order_by=order_by,
             sort_order=sort_order,
+            paginate=paginate,
             api_key=api_key,
-        ).json()
-        data = data["tags"]
-        return pd.DataFrame(data)
+        )
 
 
 class ReleaseTables(_api.API):

--- a/src/finagg/fred/api/_series.py
+++ b/src/finagg/fred/api/_series.py
@@ -103,6 +103,7 @@ class SeriesObservations(_api.API):
         aggregation_method: None | str = "avg",
         output_type: None | int = 1,
         vintage_dates: None | str | list[str] = None,
+        paginate: bool = False,
         api_key: None | str = None,
     ) -> pd.DataFrame:
         """Get the observations or data values for an economic data series.
@@ -177,6 +178,8 @@ class SeriesObservations(_api.API):
             vintage_dates: Vintage dates used to download data as it existed on these
                 specified dates in history. Vintage dates can be specified instead of
                 realtime periods.
+            paginate: Whether to manage `offset` automatically, making multiple
+                API calls until all results are returned.
             api_key: Your FRED API key. Defaults to the ``FRED_API_KEY``
                 environment variable.
 
@@ -199,7 +202,8 @@ class SeriesObservations(_api.API):
             4     1949-08-26   1953-02-26  1949-07-01  168.5  CPIAUCNS
 
         """
-        data = _api.get(
+        df = _api.paginate(
+            "observations",
             cls.url,
             series_id=series_id,
             realtime_start=realtime_start,
@@ -214,10 +218,9 @@ class SeriesObservations(_api.API):
             aggregation_method=aggregation_method,
             output_type=output_type,
             vintage_dates=vintage_dates,
+            paginate=paginate,
             api_key=api_key,
-        ).json()
-        data = data["observations"]
-        df = pd.DataFrame(data)
+        )
         df["series_id"] = series_id
         df["value"] = pd.to_numeric(df["value"], errors="coerce")
         return df
@@ -422,6 +425,7 @@ class SeriesSearchRelatedTags(_api.API):
         offset: None | int = 0,
         order_by: None | str = None,
         sort_order: None | str = None,
+        paginate: bool = False,
         api_key: None | str = None,
     ) -> pd.DataFrame:
         """Get the related tags for a series search.
@@ -462,6 +466,8 @@ class SeriesSearchRelatedTags(_api.API):
 
             sort_order: Sort results in ascending ("asc") or descending ("desc")
                 order for the attribute values specified by `order_by`.
+            paginate: Whether to manage `offset` automatically, making multiple
+                API calls until all results are returned.
             api_key: Your FRED API key. Defaults to the ``FRED_API_KEY``
                 environment variable.
 
@@ -480,7 +486,8 @@ class SeriesSearchRelatedTags(_api.API):
             4  public domain: citation requested       cc                     None  2018-12-17 23:33:13-06 ...
 
         """
-        data = _api.get(
+        return _api.paginate(
+            "tags",
             cls.url,
             series_search_text=series_search_text,
             realtime_start=realtime_start,
@@ -493,10 +500,9 @@ class SeriesSearchRelatedTags(_api.API):
             offset=offset,
             order_by=order_by,
             sort_order=sort_order,
+            paginate=paginate,
             api_key=api_key,
-        ).json()
-        data = data["tags"]
-        return pd.DataFrame(data)
+        )
 
 
 class SeriesSearchTags(_api.API):
@@ -525,6 +531,7 @@ class SeriesSearchTags(_api.API):
         offset: None | int = 0,
         order_by: None | str = None,
         sort_order: None | str = None,
+        paginate: bool = False,
         api_key: None | str = None,
     ) -> pd.DataFrame:
         """Get the tags for a series search.
@@ -564,6 +571,8 @@ class SeriesSearchTags(_api.API):
 
             sort_order: Sort results in ascending ("asc") or descending ("desc")
                 order for the attribute values specified by `order_by`.
+            paginate: Whether to manage `offset` automatically, making multiple
+                API calls until all results are returned.
             api_key: Your FRED API key. Defaults to the ``FRED_API_KEY``
                 environment variable.
 
@@ -582,7 +591,8 @@ class SeriesSearchTags(_api.API):
             4  public domain: citation requested       cc                     None ...
 
         """
-        data = _api.get(
+        return _api.paginate(
+            "tags",
             cls.url,
             series_search_text=series_search_text,
             realtime_start=realtime_start,
@@ -594,10 +604,9 @@ class SeriesSearchTags(_api.API):
             offset=offset,
             order_by=order_by,
             sort_order=sort_order,
+            paginate=paginate,
             api_key=api_key,
-        ).json()
-        data = data["tags"]
-        return pd.DataFrame(data)
+        )
 
 
 class SeriesSearch(_api.API):
@@ -644,6 +653,7 @@ class SeriesSearch(_api.API):
         filter_value: None | str = None,
         tag_names: None | str | list[str] = None,
         exclude_tag_names: None | str | list[str] = None,
+        paginate: bool = False,
         api_key: None | str = None,
     ) -> pd.DataFrame:
         """Get economic data series that match search text.
@@ -695,6 +705,8 @@ class SeriesSearch(_api.API):
                 results by.
             tag_names: List of tag names that series match all of.
             exclude_tag_names: List of tag names that series match none of.
+            paginate: Whether to manage `offset` automatically, making multiple
+                API calls until all results are returned.
             api_key: Your FRED API key. Defaults to the ``FRED_API_KEY``
                 environment variable.
 
@@ -711,7 +723,8 @@ class SeriesSearch(_api.API):
             4    CSUSHPISA     2023-03-16   2023-03-16    S&P/Case-Shiller U.S. National Home Price Index ...
 
         """
-        data = _api.get(
+        return _api.paginate(
+            "seriess",
             cls.url,
             search_text=search_text,
             search_type=search_type,
@@ -725,10 +738,9 @@ class SeriesSearch(_api.API):
             filter_value=filter_value,
             tag_names=tag_names,
             exclude_tag_names=exclude_tag_names,
+            paginate=paginate,
             api_key=api_key,
-        ).json()
-        data = data["seriess"]
-        return pd.DataFrame(data)
+        )
 
 
 class SeriesTags(_api.API):
@@ -828,6 +840,7 @@ class SeriesUpdates(_api.API):
         filter_value: None | str = None,
         start_time: None | str = None,
         end_time: None | str = None,
+        paginate: bool = False,
         api_key: None | str = None,
     ) -> pd.DataFrame:
         """Get economic data series sorted by when observations
@@ -858,6 +871,8 @@ class SeriesUpdates(_api.API):
                 Can filter down to minutes. Expects format "YYYMMDDHhmm".
             end_time: Start time for limiting results for a time range.
                 Can filter down to minutes. Expects format "YYYMMDDHhmm".
+            paginate: Whether to manage `offset` automatically, making multiple
+                API calls until all results are returned.
             api_key: Your FRED API key. Defaults to the ``FRED_API_KEY``
                 environment variable.
 
@@ -866,7 +881,8 @@ class SeriesUpdates(_api.API):
             data series.
 
         """
-        data = _api.get(
+        return _api.paginate(
+            "seriess",
             cls.url,
             realtime_start=realtime_start,
             realtime_end=realtime_end,
@@ -875,10 +891,9 @@ class SeriesUpdates(_api.API):
             filter_value=filter_value,
             start_time=start_time,
             end_time=end_time,
+            paginate=paginate,
             api_key=api_key,
-        ).json()
-        data = data["seriess"]
-        return pd.DataFrame(data)
+        )
 
 
 class SeriesVintageDates(_api.API):
@@ -925,12 +940,17 @@ class SeriesVintageDates(_api.API):
             offset: Result start offset.
             sort_order: Sort results in ascending ("asc") or descending ("desc")
                 vintage date order.
+            paginate: Whether to manage `offset` automatically, making multiple
+                API calls until all results are returned.
+            api_key: Your FRED API key. Defaults to the ``FRED_API_KEY``
+                environment variable.
 
         Returns:
             A dataframe containing dates on vintage release dates for a series.
 
         """
-        data = _api.get(
+        return _api.paginate(
+            "seriess",
             cls.url,
             series_id=series_id,
             realtime_start=realtime_start,
@@ -939,9 +959,7 @@ class SeriesVintageDates(_api.API):
             offset=offset,
             sort_order=sort_order,
             api_key=api_key,
-        ).json()
-        data = data["seriess"]
-        return pd.DataFrame(data)
+        )
 
 
 class Series(_api.API):

--- a/src/finagg/fred/api/_series.py
+++ b/src/finagg/fred/api/_series.py
@@ -202,7 +202,7 @@ class SeriesObservations(_api.API):
             4     1949-08-26   1953-02-26  1949-07-01  168.5  CPIAUCNS
 
         """
-        df = _api.paginate(
+        df = _api.maybe_paginate(
             "observations",
             cls.url,
             series_id=series_id,
@@ -486,7 +486,7 @@ class SeriesSearchRelatedTags(_api.API):
             4  public domain: citation requested       cc                     None  2018-12-17 23:33:13-06 ...
 
         """
-        return _api.paginate(
+        return _api.maybe_paginate(
             "tags",
             cls.url,
             series_search_text=series_search_text,
@@ -591,7 +591,7 @@ class SeriesSearchTags(_api.API):
             4  public domain: citation requested       cc                     None ...
 
         """
-        return _api.paginate(
+        return _api.maybe_paginate(
             "tags",
             cls.url,
             series_search_text=series_search_text,
@@ -723,7 +723,7 @@ class SeriesSearch(_api.API):
             4    CSUSHPISA     2023-03-16   2023-03-16    S&P/Case-Shiller U.S. National Home Price Index ...
 
         """
-        return _api.paginate(
+        return _api.maybe_paginate(
             "seriess",
             cls.url,
             search_text=search_text,
@@ -881,7 +881,7 @@ class SeriesUpdates(_api.API):
             data series.
 
         """
-        return _api.paginate(
+        return _api.maybe_paginate(
             "seriess",
             cls.url,
             realtime_start=realtime_start,
@@ -918,6 +918,7 @@ class SeriesVintageDates(_api.API):
         limit: None | int = 10000,
         offset: None | int = 0,
         sort_order: None | str = None,
+        paginate: bool = False,
         api_key: None | str = None,
     ) -> pd.DataFrame:
         """Get the dates in history when a series' data values were revised
@@ -949,7 +950,7 @@ class SeriesVintageDates(_api.API):
             A dataframe containing dates on vintage release dates for a series.
 
         """
-        return _api.paginate(
+        return _api.maybe_paginate(
             "seriess",
             cls.url,
             series_id=series_id,
@@ -958,6 +959,7 @@ class SeriesVintageDates(_api.API):
             limit=limit,
             offset=offset,
             sort_order=sort_order,
+            paginate=paginate,
             api_key=api_key,
         )
 

--- a/src/finagg/fred/api/_source.py
+++ b/src/finagg/fred/api/_source.py
@@ -34,6 +34,7 @@ class SourceReleases(_api.API):
         offset: None | int = 0,
         order_by: None | str = None,
         sort_order: None | str = None,
+        paginate: bool = False,
         api_key: None | str = None,
     ) -> pd.DataFrame:
         """Get all releases for a source of economic data.
@@ -60,6 +61,8 @@ class SourceReleases(_api.API):
 
             sort_order: Sort results in ascending ("asc") or
                 descending ("desc") order.
+            paginate: Whether to manage `offset` automatically, making multiple
+                API calls until all results are returned.
             api_key: Your FRED API key. Defaults to the ``FRED_API_KEY``
                 environment variable.
 
@@ -77,7 +80,8 @@ class SourceReleases(_api.API):
             4  18     2023-03-15   2023-03-15                       H.15 Selected Interest Rates           True  http://www.federalreserve.gov/releases/h15/
 
         """
-        data = _api.get(
+        return _api.maybe_paginate(
+            "releases",
             cls.url,
             source_id=source_id,
             realtime_start=realtime_start,
@@ -86,10 +90,9 @@ class SourceReleases(_api.API):
             offset=offset,
             order_by=order_by,
             sort_order=sort_order,
+            paginate=paginate,
             api_key=api_key,
-        ).json()
-        data = data["releases"]
-        return pd.DataFrame(data)
+        )
 
 
 class Source(_api.API):
@@ -176,6 +179,7 @@ class Sources(_api.API):
         offset: None | int = 0,
         order_by: None | str = None,
         sort_order: None | str = None,
+        paginate: bool = False,
         api_key: None | str = None,
     ) -> pd.DataFrame:
         """Get all sources of economic data.
@@ -201,6 +205,8 @@ class Sources(_api.API):
 
             sort_order: Sort results in ascending ("asc") or
                 descending ("desc") order.
+            paginate: Whether to manage `offset` automatically, making multiple
+                API calls until all results are returned.
             api_key: Your FRED API key. Defaults to the ``FRED_API_KEY``
                 environment variable.
 
@@ -218,7 +224,8 @@ class Sources(_api.API):
             4  11     2023-03-15   2023-03-15                                Dow Jones & Company           http://www.dowjones.com
 
         """
-        data = _api.get(
+        return _api.maybe_paginate(
+            "sources",
             cls.url,
             realtime_start=realtime_start,
             realtime_end=realtime_end,
@@ -226,7 +233,6 @@ class Sources(_api.API):
             offset=offset,
             order_by=order_by,
             sort_order=sort_order,
+            paginate=paginate,
             api_key=api_key,
-        ).json()
-        data = data["sources"]
-        return pd.DataFrame(data)
+        )

--- a/src/finagg/fred/api/_tags.py
+++ b/src/finagg/fred/api/_tags.py
@@ -36,6 +36,7 @@ class RelatedTags(_api.API):
         offset: None | int = 0,
         order_by: None | str = None,
         sort_order: None | str = None,
+        paginate: bool = False,
         api_key: None | str = None,
     ) -> pd.DataFrame:
         """Get data for tags related to an economic release.
@@ -74,6 +75,8 @@ class RelatedTags(_api.API):
 
             sort_order: Sort results in ascending ("asc") or
                 descending ("desc") order.
+            paginate: Whether to manage `offset` automatically, making multiple
+                API calls until all results are returned.
             api_key: Your FRED API key. Defaults to the ``FRED_API_KEY``
                 environment variable.
 
@@ -90,7 +93,8 @@ class RelatedTags(_api.API):
             4                                gdp      gen    Gross Domestic Product  2012-02-27 10:18:19-06          81         60040
 
         """
-        data = _api.get(
+        return _api.maybe_paginate(
+            "tags",
             cls.url,
             realtime_start=realtime_start,
             realtime_end=realtime_end,
@@ -102,10 +106,9 @@ class RelatedTags(_api.API):
             offset=offset,
             order_by=order_by,
             sort_order=sort_order,
+            paginate=paginate,
             api_key=api_key,
-        ).json()
-        data = data["tags"]
-        return pd.DataFrame(data)
+        )
 
 
 class Series(_api.API):
@@ -131,6 +134,7 @@ class Series(_api.API):
         offset: None | int = 0,
         order_by: None | str = None,
         sort_order: None | str = None,
+        paginate: bool = False,
         api_key: None | str = None,
     ) -> pd.DataFrame:
         """Get the economic data series matching tags.
@@ -165,6 +169,8 @@ class Series(_api.API):
 
             sort_order: Sort results in ascending ("asc") or
                 descending ("desc") order.
+            paginate: Whether to manage `offset` automatically, making multiple
+                API calls until all results are returned.
             api_key: Your FRED API key. Defaults to the ``FRED_API_KEY``
                 environment variable.
 
@@ -181,7 +187,8 @@ class Series(_api.API):
             4  A001RL1A225NBEA     2023-03-15   2023-03-15                       Real Gross National Product ...
 
         """
-        data = _api.get(
+        return _api.maybe_paginate(
+            "seriess",
             cls.url,
             tag_names=tag_names,
             exclude_tag_names=exclude_tag_names,
@@ -191,10 +198,9 @@ class Series(_api.API):
             offset=offset,
             order_by=order_by,
             sort_order=sort_order,
+            paginate=paginate,
             api_key=api_key,
-        ).json()
-        data = data["seriess"]
-        return pd.DataFrame(data)
+        )
 
 
 class Tags(_api.API):
@@ -228,6 +234,7 @@ class Tags(_api.API):
         offset: None | int = 0,
         order_by: None | str = None,
         sort_order: None | str = None,
+        paginate: bool = False,
         api_key: None | str = None,
     ) -> pd.DataFrame:
         """Get the FRED tags for a series.
@@ -266,6 +273,8 @@ class Tags(_api.API):
 
             sort_order: Sort results in ascending ("asc") or
                 descending ("desc") order.
+            paginate: Whether to manage `offset` automatically, making multiple
+                API calls until all results are returned.
             api_key: Your FRED API key. Defaults to the ``FRED_API_KEY``
                 environment variable.
 
@@ -282,7 +291,8 @@ class Tags(_api.API):
             4      frb stl      src                St. Louis Fed  2012-02-27 10:18:19-06          68         78442
 
         """
-        data = _api.get(
+        return _api.maybe_paginate(
+            "tags",
             cls.url,
             realtime_start=realtime_start,
             realtime_end=realtime_end,
@@ -294,6 +304,4 @@ class Tags(_api.API):
             order_by=order_by,
             sort_order=sort_order,
             api_key=api_key,
-        ).json()
-        data = data["tags"]
-        return pd.DataFrame(data)
+        )


### PR DESCRIPTION
Wrapping a lot of FRED API getters to add a `paginate` option to automatically handle result pagination with the FRED API