### PR TITLE
Add FXMacroData API client

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,14 @@ Get Federal Reserve Economic Data (FRED).
 4     1949-08-26   1953-02-26  1949-07-01  168.5  CPIAUCNS
 ```
 
+Get FXMacroData macro event data.
+
+```pycon
+>>> finagg.fxmacrodata.api.calendar("usd").head(5)
+  indicator release_date ...
+0       cpi   2026-01-01 ...
+```
+
 Get Securities and Exchange Commission (SEC) filings.
 
 ```pycon
@@ -179,6 +187,9 @@ configuring API keys and user agents:
   a free API key from the [BEA API site][3].
 * ``FRED_API_KEY`` is for the Federal Reserve Economic Data API key. You can get
   a free API key from the [FRED API site][8].
+* ``FXMD_API_KEY`` or ``FXMACRODATA_API_KEY`` is for protected FXMacroData API
+  coverage. Public USD catalogue, calendar, and macro announcement examples can
+  be used without an API key.
 * ``SEC_API_USER_AGENT`` is for the Securities and Exchange Commission's API. This
   should be of the format ``FIRST_NAME LAST_NAME E_MAIL``.
 
@@ -216,6 +227,7 @@ You can change some **finagg** behavior with other environment variables:
 
 * The [BEA API][1] and the [BEA API key registration link][2].
 * The [FRED API][6] and the [FRED API key registration link][7].
+* The [FXMacroData API][18] and [FXMacroData documentation][19].
 * The [SEC API][14].
 
 # Related Projects
@@ -277,3 +289,5 @@ degradation on Windows.
 [15]: https://github.com/sec-edgar/sec-edgar
 [16]: https://github.com/jadchaar/sec-edgar-api
 [17]: https://www.sqlalchemy.org/
+[18]: https://api.fxmacrodata.com/openapi.json
+[19]: https://fxmacrodata.com/documentation

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,6 +15,10 @@ analysis.
   methods for retrieving, searching, and describing economic data from a variety
   of sources. The FRED API is one of the most popular APIs in the finance
   industry.
+* The `FXMacroData API`_. The FXMacroData API provides macroeconomic
+  announcements, release calendars, forecast/consensus rows, FX spot history,
+  COT positioning, commodities, and market-session context for FX and macro
+  research workflows.
 * The Securities and Exchange Commission’s `(SEC) EDGAR API`_. The SEC EDGAR
   API provides methods for retrieving XBRL data (e.g., earnings per share) from
   financial statements and methods for retrieving SEC filing submission
@@ -47,4 +51,5 @@ Alphabetically-ordered index of all package members.
 
 .. _`(BEA) API`: https://apps.bea.gov/api/signup/
 .. _`(FRED) API`: https://fred.stlouisfed.org/docs/api/fred/
+.. _`FXMacroData API`: https://fxmacrodata.com/documentation
 .. _`(SEC) EDGAR API`: https://www.sec.gov/edgar/sec-api-documentation

--- a/src/finagg/__init__.py
+++ b/src/finagg/__init__.py
@@ -6,7 +6,7 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
-from . import bea, config, fred, sec, testing, utils
+from . import bea, config, fred, fxmacrodata, sec, testing, utils
 
 try:
     __version__ = version("finagg")

--- a/src/finagg/fxmacrodata/__init__.py
+++ b/src/finagg/fxmacrodata/__init__.py
@@ -1,0 +1,5 @@
+"""FXMacroData API implementation."""
+
+from . import api
+
+__all__ = ["api"]

--- a/src/finagg/fxmacrodata/api.py
+++ b/src/finagg/fxmacrodata/api.py
@@ -1,0 +1,442 @@
+"""An implementation of the FXMacroData API.
+
+FXMacroData provides macroeconomic announcements, release calendars,
+forecast/consensus rows, FX spot history, COT positioning, commodity series,
+and market-session context for FX and macro research workflows.
+
+Public USD catalogue, calendar, and macro announcement examples work without
+an API key. Protected coverage can be accessed by passing ``api_key`` directly
+or by setting ``FXMD_API_KEY`` or ``FXMACRODATA_API_KEY`` in the environment.
+
+See the official `FXMacroData docs`_ for endpoint-level details.
+
+.. _`FXMacroData docs`: https://fxmacrodata.com/documentation
+"""
+
+import os
+from datetime import timedelta
+from typing import Any
+
+import pandas as pd
+import requests
+import requests_cache
+
+from .. import config
+
+if config.disable_http_cache:
+    session = requests.Session()
+else:
+    session = requests_cache.CachedSession(
+        str(config.http_cache_path),
+        ignored_parameters=["api_key"],
+        expire_after=timedelta(hours=1),
+    )
+
+
+#: The FXMacroData API base URL. All API requests are made under this URL.
+url = "https://api.fxmacrodata.com"
+
+
+def _api_key(api_key: None | str = None) -> None | str:
+    """Return an explicit or environment-provided FXMacroData API key."""
+    return api_key or os.environ.get("FXMD_API_KEY") or os.environ.get(
+        "FXMACRODATA_API_KEY"
+    )
+
+
+def pformat(**kwargs: Any) -> dict[str, Any]:
+    """FXMacroData API parameter formatting.
+
+    Args:
+        **kwargs: All possible FXMacroData query parameters.
+
+    Returns:
+        Mapping of request parameter name to formatted value.
+    """
+    params: dict[str, Any] = {}
+    for key, value in kwargs.items():
+        if value is None:
+            continue
+        if isinstance(value, bool):
+            params[key] = "true" if value else "false"
+        else:
+            params[key] = value
+    return params
+
+
+def get(path: str, /, *, api_key: None | str = None, **kwargs: Any) -> requests.Response:
+    """Main API get function used by all FXMacroData methods.
+
+    Args:
+        path: API path under :data:`url`.
+        api_key: Optional FXMacroData API key.
+        **kwargs: Query parameters.
+
+    Returns:
+        A valid FXMacroData API response.
+    """
+    headers: dict[str, str] = {}
+    key = _api_key(api_key)
+    if key:
+        headers["X-API-Key"] = key
+
+    response = session.get(
+        f"{url}{path}",
+        params=pformat(**kwargs),
+        headers=headers or None,
+    )
+    response.raise_for_status()
+    return response
+
+
+def _frame(payload: Any) -> pd.DataFrame:
+    """Normalize common FXMacroData response containers into a dataframe."""
+    if isinstance(payload, list):
+        return pd.json_normalize(payload)
+
+    if isinstance(payload, dict):
+        for key in (
+            "data",
+            "items",
+            "results",
+            "records",
+            "calendar",
+            "announcements",
+            "predictions",
+            "series",
+            "cot",
+            "commodities",
+            "sessions",
+            "indicators",
+            "capabilities",
+        ):
+            value = payload.get(key)
+            if isinstance(value, list):
+                df = pd.json_normalize(value)
+                for meta_key, meta_value in payload.items():
+                    if meta_key == key or isinstance(meta_value, (dict, list)):
+                        continue
+                    if meta_key not in df.columns:
+                        df[meta_key] = meta_value
+                return df
+        return pd.json_normalize(payload)
+
+    return pd.DataFrame({"value": [payload]})
+
+
+def data_catalogue(
+    currency: str = "usd",
+    /,
+    *,
+    include_capabilities: None | bool = None,
+    include_coverage: None | bool = None,
+    indicator: None | str = None,
+    api_key: None | str = None,
+) -> pd.DataFrame:
+    """Get FXMacroData catalogue and coverage metadata.
+
+    Args:
+        currency: Three-letter currency code, such as ``"usd"``.
+        include_capabilities: Include endpoint capability metadata.
+        include_coverage: Include coverage metadata.
+        indicator: Filter catalogue rows to one indicator.
+        api_key: Optional FXMacroData API key.
+
+    Returns:
+        Dataframe of catalogue rows.
+    """
+    response = get(
+        f"/v1/data_catalogue/{currency.lower()}",
+        include_capabilities=include_capabilities,
+        include_coverage=include_coverage,
+        indicator=indicator,
+        api_key=api_key,
+    )
+    return _frame(response.json())
+
+
+def indicator(
+    currency: str,
+    indicator_: str,
+    /,
+    *,
+    start_date: None | str = None,
+    end_date: None | str = None,
+    series_mode: None | str = None,
+    limit: None | int = None,
+    offset: None | int = None,
+    page: None | int = None,
+    seasonality: None | bool = None,
+    frequency: None | str = None,
+    revisions: None | bool = None,
+    basis: None | str = None,
+    official_only: None | bool = None,
+    api_key: None | str = None,
+) -> pd.DataFrame:
+    """Get FXMacroData macro announcement or indicator history rows.
+
+    Args:
+        currency: Three-letter currency code.
+        indicator_: FXMacroData indicator slug.
+        start_date: Optional inclusive start date in ``YYYY-MM-DD`` format.
+        end_date: Optional inclusive end date in ``YYYY-MM-DD`` format.
+        series_mode: Optional API series mode.
+        limit: Optional page size.
+        offset: Optional result offset.
+        page: Optional page number.
+        seasonality: Include seasonality fields when supported.
+        frequency: Optional result frequency.
+        revisions: Include revision rows when supported.
+        basis: Optional basis parameter.
+        official_only: Filter to official-source rows when supported.
+        api_key: Optional FXMacroData API key.
+
+    Returns:
+        Dataframe of announcement or indicator rows.
+    """
+    response = get(
+        f"/v1/announcements/{currency.lower()}/{indicator_}",
+        start_date=start_date,
+        end_date=end_date,
+        series_mode=series_mode,
+        limit=limit,
+        offset=offset,
+        page=page,
+        seasonality=seasonality,
+        frequency=frequency,
+        revisions=revisions,
+        basis=basis,
+        official_only=official_only,
+        api_key=api_key,
+    )
+    return _frame(response.json())
+
+
+def calendar(
+    currency: str = "usd",
+    /,
+    *,
+    indicator_: None | str = None,
+    start_date: None | str = None,
+    end_date: None | str = None,
+    timezone: None | str = None,
+    api_key: None | str = None,
+) -> pd.DataFrame:
+    """Get FXMacroData economic release-calendar rows.
+
+    Args:
+        currency: Three-letter currency code.
+        indicator_: Optional indicator slug filter.
+        start_date: Optional inclusive start date in ``YYYY-MM-DD`` format.
+        end_date: Optional inclusive end date in ``YYYY-MM-DD`` format.
+        timezone: Optional timezone for announcement datetimes.
+        api_key: Optional FXMacroData API key.
+
+    Returns:
+        Dataframe of release-calendar rows.
+    """
+    response = get(
+        f"/v1/calendar/{currency.lower()}",
+        indicator=indicator_,
+        start_date=start_date,
+        end_date=end_date,
+        timezone=timezone,
+        api_key=api_key,
+    )
+    return _frame(response.json())
+
+
+def latest_announcements(
+    currency: str = "usd",
+    /,
+    *,
+    api_key: None | str = None,
+) -> pd.DataFrame:
+    """Get the latest FXMacroData announcements for a currency.
+
+    Args:
+        currency: Three-letter currency code.
+        api_key: Optional FXMacroData API key.
+
+    Returns:
+        Dataframe of latest announcement rows.
+    """
+    response = get(f"/v1/announcements/{currency.lower()}/latest", api_key=api_key)
+    return _frame(response.json())
+
+
+def predictions(
+    currency: str,
+    indicator_: str,
+    /,
+    *,
+    prediction_type: None | str = None,
+    prediction_source: None | str = None,
+    start_date: None | str = None,
+    end_date: None | str = None,
+    limit: None | int = None,
+    offset: None | int = None,
+    page: None | int = None,
+    api_key: None | str = None,
+) -> pd.DataFrame:
+    """Get FXMacroData prediction, consensus, or forecast rows.
+
+    Args:
+        currency: Three-letter currency code.
+        indicator_: FXMacroData indicator slug.
+        prediction_type: Optional prediction type filter.
+        prediction_source: Optional prediction source filter.
+        start_date: Optional inclusive start date in ``YYYY-MM-DD`` format.
+        end_date: Optional inclusive end date in ``YYYY-MM-DD`` format.
+        limit: Optional page size.
+        offset: Optional result offset.
+        page: Optional page number.
+        api_key: Optional FXMacroData API key.
+
+    Returns:
+        Dataframe of prediction rows.
+    """
+    response = get(
+        f"/v1/predictions/{currency.lower()}/{indicator_}",
+        prediction_type=prediction_type,
+        prediction_source=prediction_source,
+        start_date=start_date,
+        end_date=end_date,
+        limit=limit,
+        offset=offset,
+        page=page,
+        api_key=api_key,
+    )
+    return _frame(response.json())
+
+
+def forex(
+    base: str,
+    quote: str = "usd",
+    /,
+    *,
+    start_date: None | str = None,
+    end_date: None | str = None,
+    limit: None | int = None,
+    offset: None | int = None,
+    page: None | int = None,
+    indicators: None | str = None,
+    api_key: None | str = None,
+) -> pd.DataFrame:
+    """Get FXMacroData FX spot history rows.
+
+    Args:
+        base: Base currency code.
+        quote: Quote currency code.
+        start_date: Optional inclusive start date in ``YYYY-MM-DD`` format.
+        end_date: Optional inclusive end date in ``YYYY-MM-DD`` format.
+        limit: Optional page size.
+        offset: Optional result offset.
+        page: Optional page number.
+        indicators: Optional derived-indicator selection.
+        api_key: Optional FXMacroData API key.
+
+    Returns:
+        Dataframe of FX spot rows.
+    """
+    response = get(
+        f"/v1/forex/{base.lower()}/{quote.lower()}",
+        start_date=start_date,
+        end_date=end_date,
+        limit=limit,
+        offset=offset,
+        page=page,
+        indicators=indicators,
+        api_key=api_key,
+    )
+    return _frame(response.json())
+
+
+def cot(
+    currency: str,
+    /,
+    *,
+    start_date: None | str = None,
+    end_date: None | str = None,
+    limit: None | int = None,
+    offset: None | int = None,
+    page: None | int = None,
+    api_key: None | str = None,
+) -> pd.DataFrame:
+    """Get FXMacroData COT positioning rows.
+
+    Args:
+        currency: Three-letter currency code.
+        start_date: Optional inclusive start date in ``YYYY-MM-DD`` format.
+        end_date: Optional inclusive end date in ``YYYY-MM-DD`` format.
+        limit: Optional page size.
+        offset: Optional result offset.
+        page: Optional page number.
+        api_key: Optional FXMacroData API key.
+
+    Returns:
+        Dataframe of COT positioning rows.
+    """
+    response = get(
+        f"/v1/cot/{currency.lower()}",
+        start_date=start_date,
+        end_date=end_date,
+        limit=limit,
+        offset=offset,
+        page=page,
+        api_key=api_key,
+    )
+    return _frame(response.json())
+
+
+def commodities(
+    indicator_: str,
+    /,
+    *,
+    start_date: None | str = None,
+    end_date: None | str = None,
+    limit: None | int = None,
+    offset: None | int = None,
+    page: None | int = None,
+    api_key: None | str = None,
+) -> pd.DataFrame:
+    """Get FXMacroData commodity or energy rows.
+
+    Args:
+        indicator_: FXMacroData commodity indicator slug.
+        start_date: Optional inclusive start date in ``YYYY-MM-DD`` format.
+        end_date: Optional inclusive end date in ``YYYY-MM-DD`` format.
+        limit: Optional page size.
+        offset: Optional result offset.
+        page: Optional page number.
+        api_key: Optional FXMacroData API key.
+
+    Returns:
+        Dataframe of commodity rows.
+    """
+    response = get(
+        f"/v1/commodities/{indicator_}",
+        start_date=start_date,
+        end_date=end_date,
+        limit=limit,
+        offset=offset,
+        page=page,
+        api_key=api_key,
+    )
+    return _frame(response.json())
+
+
+def market_sessions(
+    *,
+    at: None | str = None,
+) -> pd.DataFrame:
+    """Get FXMacroData market-session rows.
+
+    Args:
+        at: Optional timestamp to evaluate sessions at.
+
+    Returns:
+        Dataframe of market-session rows.
+    """
+    response = get("/v1/market_sessions", at=at)
+    return _frame(response.json())

--- a/tests/test_fxmacrodata/__init__.py
+++ b/tests/test_fxmacrodata/__init__.py
@@ -1,0 +1,1 @@
+"""FXMacroData API tests."""

--- a/tests/test_fxmacrodata/test_api.py
+++ b/tests/test_fxmacrodata/test_api.py
@@ -1,0 +1,99 @@
+from typing import Any
+
+import finagg
+
+
+class MockResponse:
+    def __init__(self, payload: Any) -> None:
+        self.payload = payload
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self) -> Any:
+        return self.payload
+
+
+def test_calendar_get(monkeypatch: Any) -> None:
+    calls: list[dict[str, Any]] = []
+
+    def get(url: str, **kwargs: Any) -> MockResponse:
+        calls.append({"url": url, **kwargs})
+        return MockResponse(
+            {
+                "currency": "usd",
+                "calendar": [
+                    {
+                        "indicator": "cpi",
+                        "release_date": "2026-01-01",
+                    }
+                ],
+            }
+        )
+
+    monkeypatch.setattr(finagg.fxmacrodata.api.session, "get", get)
+
+    df = finagg.fxmacrodata.api.calendar(
+        "usd",
+        indicator_="cpi",
+        start_date="2026-01-01",
+        end_date="2026-01-31",
+    )
+
+    assert calls[0]["url"].endswith("/v1/calendar/usd")
+    assert calls[0]["params"] == {
+        "indicator": "cpi",
+        "start_date": "2026-01-01",
+        "end_date": "2026-01-31",
+    }
+    assert df.loc[0, "indicator"] == "cpi"
+    assert df.loc[0, "currency"] == "usd"
+
+
+def test_data_catalogue_uses_api_key_header(monkeypatch: Any) -> None:
+    calls: list[dict[str, Any]] = []
+
+    def get(url: str, **kwargs: Any) -> MockResponse:
+        calls.append({"url": url, **kwargs})
+        return MockResponse({"indicators": [{"indicator": "cpi"}]})
+
+    monkeypatch.setattr(finagg.fxmacrodata.api.session, "get", get)
+
+    df = finagg.fxmacrodata.api.data_catalogue(
+        "usd",
+        include_capabilities=True,
+        api_key="test-key",
+    )
+
+    assert calls[0]["url"].endswith("/v1/data_catalogue/usd")
+    assert calls[0]["headers"] == {"X-API-Key": "test-key"}
+    assert calls[0]["params"] == {"include_capabilities": "true"}
+    assert df.loc[0, "indicator"] == "cpi"
+
+
+def test_endpoint_helpers(monkeypatch: Any) -> None:
+    urls: list[str] = []
+
+    def get(url: str, **kwargs: Any) -> MockResponse:
+        urls.append(url)
+        return MockResponse([{"ok": True}])
+
+    monkeypatch.setattr(finagg.fxmacrodata.api.session, "get", get)
+
+    finagg.fxmacrodata.api.indicator("usd", "cpi")
+    finagg.fxmacrodata.api.latest_announcements("usd")
+    finagg.fxmacrodata.api.predictions("usd", "cpi")
+    finagg.fxmacrodata.api.forex("eur", "usd")
+    finagg.fxmacrodata.api.cot("usd")
+    finagg.fxmacrodata.api.commodities("xau_usd")
+    finagg.fxmacrodata.api.market_sessions()
+
+    assert [url.removeprefix(finagg.fxmacrodata.api.url) for url in urls] == [
+        "/v1/announcements/usd/cpi",
+        "/v1/announcements/usd/latest",
+        "/v1/predictions/usd/cpi",
+        "/v1/forex/eur/usd",
+        "/v1/cot/usd",
+        "/v1/commodities/xau_usd",
+        "/v1/market_sessions",
+    ]


### PR DESCRIPTION
## Summary
- add a `finagg.fxmacrodata.api` subpackage with cached DataFrame helpers for FXMacroData macro and market-context endpoints
- expose FXMacroData from the top-level `finagg` import and document the provider in README/docs
- add mocked tests for request construction, API-key header handling, and endpoint helper routing

## FXMacroData coverage
| Capability | finagg surface | Status |
| --- | --- | --- |
| Discovery/catalogue | `finagg.fxmacrodata.api.data_catalogue` | Native DataFrame helper |
| Macro indicator history | `finagg.fxmacrodata.api.indicator` | Native DataFrame helper |
| Release calendar | `finagg.fxmacrodata.api.calendar` | Native DataFrame helper |
| Event predictions | `finagg.fxmacrodata.api.predictions` | Native DataFrame helper |
| FX spot history | `finagg.fxmacrodata.api.forex` | Native DataFrame helper |
| FX market sessions | `finagg.fxmacrodata.api.market_sessions` | Native DataFrame helper |
| COT positioning | `finagg.fxmacrodata.api.cot` | Native DataFrame helper |
| Commodities | `finagg.fxmacrodata.api.commodities` | Native DataFrame helper |

## Validation
- `python -m py_compile src\\finagg\\fxmacrodata\\api.py src\\finagg\\fxmacrodata\\__init__.py src\\finagg\\__init__.py tests\\test_fxmacrodata\\test_api.py`
- `python -m pytest --rootdir=. tests\\test_fxmacrodata -q`
- `python -m mypy src\\finagg\\fxmacrodata src\\finagg\\__init__.py`
- `git diff --check`
